### PR TITLE
amqp openshiftize

### DIFF
--- a/whirlwind_caravan/Dockerfile.master
+++ b/whirlwind_caravan/Dockerfile.master
@@ -1,7 +1,8 @@
 FROM openshift-spark-base
 
-RUN yum install -y python-pymongo python-requests && \
-    yum clean all
+RUN yum install -y python-pip python-requests && \
+    yum clean all && \
+    pip install pymongo==3.0.3
 
 ADD caravan_master.py /
 ADD start_master.sh /

--- a/whirlwind_caravan/Dockerfile.master
+++ b/whirlwind_caravan/Dockerfile.master
@@ -4,10 +4,8 @@ RUN yum install -y python-pymongo python-requests && \
     yum clean all
 
 ADD caravan_master.py /
+ADD start_master.sh /
 
-ENTRYPOINT ["/opt/spark/bin/spark-submit", \
-	    "/caravan_master.py", \
-	    "--port", "1984", \
-            "--master", "spark://spark-master:7077", \
-	    "--mongo", "mongo://???", \
-	    "--rest", "http://???"]
+ENTRYPOINT ["/start_master.sh", \
+	    "spark-master-badt", \
+	    "mongodb"]

--- a/whirlwind_caravan/caravan-master-controller.yaml
+++ b/whirlwind_caravan/caravan-master-controller.yaml
@@ -1,18 +1,16 @@
 kind: ReplicationController
 apiVersion: v1
 metadata:
-  name: caravan-controller
+  name: caravan-master-controller
 spec:
   replicas: 1
   selector:
-    component: caravan
+    component: caravan-master
   template:
     metadata:
       labels:
-        component: caravan
+        component: caravan-master
     spec:
       containers:
-        - name: caravan-pathfinder
-          image: caravan-pathfinder
         - name: caravan-master
-          image: caravan-master
+          image: 172.30.122.181:5000/uber/caravan_master

--- a/whirlwind_caravan/caravan-pathfinder-controller.yaml
+++ b/whirlwind_caravan/caravan-pathfinder-controller.yaml
@@ -1,0 +1,16 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: caravan-pathfinder-controller
+spec:
+  replicas: 1
+  selector:
+    component: caravan-pathfinder
+  template:
+    metadata:
+      labels:
+        component: caravan-pathfinder
+    spec:
+      containers:
+        - name: caravan-pathfinder
+          image: 172.30.122.181:5000/uber/caravan_pathfinder

--- a/whirlwind_caravan/caravan-pathfinder-service.yaml
+++ b/whirlwind_caravan/caravan-pathfinder-service.yaml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: caravan-pathfinder
+spec:
+  ports:
+    - port: 1984
+      targetPort: 1984
+  selector:
+    component: caravan-pathfinder

--- a/whirlwind_caravan/caravan.yaml
+++ b/whirlwind_caravan/caravan.yaml
@@ -1,0 +1,18 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: caravan-controller
+spec:
+  replicas: 1
+  selector:
+    component: caravan
+  template:
+    metadata:
+      labels:
+        component: caravan
+    spec:
+      containers:
+        - name: caravan-pathfinder
+          image: caravan-pathfinder
+        - name: caravan-master
+          image: caravan-master

--- a/whirlwind_caravan/caravan_master.py
+++ b/whirlwind_caravan/caravan_master.py
@@ -65,7 +65,7 @@ def main():
     sc = SparkContext(conf=sconf)
     ssc = StreamingContext(sc, 1)
 
-    lines = ssc.socketTextStream('0.0.0.0', args.port)
+    lines = ssc.socketTextStream('caravan-pathfinder', args.port)
     lines.foreachRDD(lambda rdd: process_generic(rdd, mongo_url, rest_url))
 
     ssc.start()

--- a/whirlwind_caravan/caravan_master.py
+++ b/whirlwind_caravan/caravan_master.py
@@ -33,7 +33,7 @@ def normalize_log_lines(log_lines, service_name=None):
 
 def process_generic(rdd, mongo_url, rest_url):
     log_lines = rdd.collect()
-    print(log_lines)
+    print(len(log_lines), "processed")
     data = normalize_log_lines(log_lines)
     data['processed-at'] = datetime.datetime.now().strftime(
         '%Y-%m-%d %H:%M:%S.%f')[:-3]

--- a/whirlwind_caravan/start_master.sh
+++ b/whirlwind_caravan/start_master.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+. /common.sh
+
+MASTER_SERVICE_NAME=${1//-/_}
+echo "$(eval echo \$${MASTER_SERVICE_NAME^^}_SERVICE_HOST) spark-master" >> /tmp/hosts
+
+MONGODB_SERVICE_NAME=${2//-/_}
+echo "$(eval echo \$${MONGODB_SERVICE_NAME^^}_SERVICE_HOST) mongodb" >> /tmp/hosts
+
+# because the hostname only resolves locally
+export SPARK_LOCAL_HOSTNAME=$(hostname -i)
+
+spark-submit /caravan_master.py --port 1984 \
+                                --master spark://spark-master:7077 \
+                                --mongo mongo://mongodb \
+                                --rest http:XYZ

--- a/whirlwind_caravan/start_master.sh
+++ b/whirlwind_caravan/start_master.sh
@@ -13,5 +13,5 @@ export SPARK_LOCAL_HOSTNAME=$(hostname -i)
 
 spark-submit /caravan_master.py --port 1984 \
                                 --master spark://spark-master:7077 \
-                                --mongo mongo://mongodb \
+                                --mongo mongodb://mongodb \
                                 --rest http:XYZ

--- a/whirlwind_caravan/start_master.sh
+++ b/whirlwind_caravan/start_master.sh
@@ -13,5 +13,5 @@ export SPARK_LOCAL_HOSTNAME=$(hostname -i)
 
 spark-submit /caravan_master.py --port 1984 \
                                 --master spark://spark-master:7077 \
-                                --mongo mongodb://mongodb \
+                                --mongo mongodb://sparkhara:openstack@mongodb/sparkhara \
                                 --rest http:XYZ


### PR DESCRIPTION
in progress set of patches to get caravan running on openshift

currently the generator can publish to a broker, the pathfinder can consume from the broker, the master can consume from pathfinder. the master can run the spark jobs, but the rest notification support is incomplete and the mongodb update is failing with:

```
Traceback (most recent call last):
  File "/opt/spark/python/lib/pyspark.zip/pyspark/streaming/util.py", line 62, in call
    r = self.func(t, *rdds)
  File "/opt/spark/python/lib/pyspark.zip/pyspark/streaming/dstream.py", line 159, in <lambda>
    func = lambda t, rdd: old_func(rdd)
  File "/caravan_master.py", line 69, in <lambda>
    lines.foreachRDD(lambda rdd: process_generic(rdd, mongo_url, rest_url))
  File "/caravan_master.py", line 40, in process_generic
    store_packets(data, mongo_url)
  File "/caravan_master.py", line 23, in store_packets
    db.insert_one(data)
  File "/usr/lib64/python2.7/site-packages/pymongo/collection.py", line 1422, in __call__
    self.__name.split(".")[-1])
TypeError: 'Collection' object is not callable. If you meant to call the 'insert_one' method o
n a 'Collection' object it is failing because no such method exists.
```
